### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ The `yMin` and `yMax` properties should be self-evident. `ySteps` is an array of
 - *The sample project doesn't compile*
 
   The sample project, at the moment, needs CocoaPods. Install Cocoapods, then run `pod install` while you are in the ios-linechart directory.
-	
-## Support this project
+  
+- *Will the project support bar charts, pie charts, ...?*
 
-[![Support via Gittip](https://rawgithub.com/twolfson/gittip-badge/0.2.0/dist/gittip.png)](https://www.gittip.com/mruegenberg/)
+  No.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Just copy these into you project as well.
 
 ios-linechart uses Core Graphics, so you'll need to add `CoreGraphics.framework` to your project.
 
-Even if you don't use Cocoapods, it is recommended to use an official release, since the repository may be unstable in  between releases. Just check out the newest tagged commit.
+Even if you don't use CocoaPods, it is recommended to use an official release, since the repository may be unstable in  between releases. Just check out the newest tagged commit.
 
 
 
@@ -111,7 +111,7 @@ The `yMin` and `yMax` properties should be self-evident. `ySteps` is an array of
 
 - *The sample project doesn't compile*
 
-  The sample project, at the moment, needs CocoaPods. Install Cocoapods, then run `pod install` while you are in the ios-linechart directory.
+  The sample project, at the moment, needs CocoaPods. Install CocoaPods, then run `pod install` while you are in the ios-linechart directory.
   
 - *Will the project support bar charts, pie charts, ...?*
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ The `yMin` and `yMax` properties should be self-evident. `ySteps` is an array of
 - *The sample project doesn't compile*
 
   The sample project, at the moment, needs CocoaPods. Install CocoaPods, then run `pod install` while you are in the ios-linechart directory.
-  
-- *Will the project support bar charts, pie charts, ...?*
+	
+## Support this project
 
-  No.
+[![Support via Gittip](https://rawgithub.com/twolfson/gittip-badge/0.2.0/dist/gittip.png)](https://www.gittip.com/mruegenberg/)
 
 ## Contact
 

--- a/ios-linechart.podspec
+++ b/ios-linechart.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ios-linechart"
-  s.version      = "1.3.1"
+  s.version      = "1.3.2"
   s.summary      = "Interactive line charts / plots for the simplicity-loving iOS developer."
   s.homepage     = "https://github.com/mruegenberg/ios-linechart"
   s.screenshots  = "https://raw.github.com/mruegenberg/ios-linechart/master/doc/screenshot1.png", "https://raw.github.com/mruegenberg/ios-linechart/master/doc/screenshot2.png"

--- a/ios-linechart.podspec
+++ b/ios-linechart.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ios-linechart"
-  s.version      = "1.3.0"
+  s.version      = "1.3.1"
   s.summary      = "Interactive line charts / plots for the simplicity-loving iOS developer."
   s.homepage     = "https://github.com/mruegenberg/ios-linechart"
   s.screenshots  = "https://raw.github.com/mruegenberg/ios-linechart/master/doc/screenshot1.png", "https://raw.github.com/mruegenberg/ios-linechart/master/doc/screenshot2.png"
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.author       = { "Marcel Ruegenberg" => "github@dustlab.com" }
 
-  s.source       = { :git => "https://github.com/mruegenberg/ios-linechart.git", :tag => "1.3.0" }
+  s.source       = { :git => "https://github.com/mruegenberg/ios-linechart.git", :tag => s.version }
 
   s.platform     = :ios, '5.1'
 

--- a/ios-linechart/ChartViewController.m
+++ b/ios-linechart/ChartViewController.m
@@ -103,13 +103,13 @@
         chartView.ySteps = @[@"1.0",@"2.0",@"3.0",@"4.0",@"5.0",@"A big label at 6.0"];
         chartView.data = @[d1x,d2x];
         chartView.selectedItemCallback = ^(LCLineChartData *dat, NSUInteger item, CGPoint pos) {
-            if(dat == d1x && item == 1) {
+            if(dat == d1x && item == 2) {
                 NSLog(@"User selected item 1 in 1st graph at position %@ in the graph view", NSStringFromCGPoint(pos));
             }
         };
         
         //    chartView.drawsDataPoints = NO; // Uncomment to turn off circles at data points.
-        //    chartView.drawsDataLines = NO; // Uncomment to turn off lines connecting data points.
+        //    chartView.drawsDataLines = NO; // Uncomment to turn off lines connecting data points. (=> scatter plot)
         //    chartView.backgroundColor = [UIColor colorWithWhite:0.95 alpha:1.0]; // Uncomment for custom background color.
         
         [self.view addSubview:chartView];

--- a/ios-linechart/ChartViewController.m
+++ b/ios-linechart/ChartViewController.m
@@ -102,6 +102,11 @@
         chartView.yMax = 6;
         chartView.ySteps = @[@"1.0",@"2.0",@"3.0",@"4.0",@"5.0",@"A big label at 6.0"];
         chartView.data = @[d1x,d2x];
+        chartView.selectedItemCallback = ^(LCLineChartData *dat, NSUInteger item, CGPoint pos) {
+            if(dat == d1x && item == 1) {
+                NSLog(@"User selected item 1 in 1st graph at position %@ in the graph view", NSStringFromCGPoint(pos));
+            }
+        };
         
         //    chartView.drawsDataPoints = NO; // Uncomment to turn off circles at data points.
         //    chartView.drawsDataLines = NO; // Uncomment to turn off lines connecting data points.

--- a/ios-linechart/LCLineChartView.h
+++ b/ios-linechart/LCLineChartView.h
@@ -9,10 +9,11 @@
 #import <UIKit/UIKit.h>
 
 @class LCLineChartDataItem;
+@class LCLineChartData;
 
 typedef LCLineChartDataItem *(^LCLineChartDataGetter)(NSUInteger item);
-typedef void(^LCLineChartSelectedPoint)(LCLineChartDataItem * dateItem);
-typedef void(^LCLineChartDeselectedPoint)();
+typedef void(^LCLineChartSelectedItem)(LCLineChartData * data, NSUInteger item, CGPoint positionInChart);
+typedef void(^LCLineChartDeselectedItem)();
 
 
 @interface LCLineChartDataItem : NSObject
@@ -40,15 +41,14 @@ typedef void(^LCLineChartDeselectedPoint)();
 
 @property (copy) LCLineChartDataGetter getData;
 
-@property (copy) LCLineChartSelectedPoint notifySelectedPoint;
-
 @end
 
 
 
 @interface LCLineChartView : UIView
 
-@property (copy) LCLineChartDeselectedPoint notifyDeselectedPoint;
+@property (copy) LCLineChartSelectedItem selectedItemCallback; /// Called whenever a data point is selected
+@property (copy) LCLineChartDeselectedItem deselectedItemCallback; /// Called after a data point is deselected and before the next `selected` callback
 
 @property (nonatomic, strong) NSArray *data; /// Array of `LineChartData` objects, one for each line.
 

--- a/ios-linechart/LCLineChartView.m
+++ b/ios-linechart/LCLineChartView.m
@@ -201,7 +201,7 @@
     static CGFloat dashedPattern[] = {4,2};
 
     // draw scale and horizontal lines
-    CGFloat heightPerStep = self.ySteps == nil || [self.ySteps count] == 0 ? availableHeight : (availableHeight / ([self.ySteps count] - 1));
+    CGFloat heightPerStep = self.ySteps == nil || [self.ySteps count] <= 1 ? availableHeight : (availableHeight / ([self.ySteps count] - 1));
 
     NSUInteger i = 0;
     CGContextSaveGState(c);

--- a/ios-linechart/LCLineChartView.m
+++ b/ios-linechart/LCLineChartView.m
@@ -64,6 +64,9 @@
 
 - (BOOL)drawsAnyData;
 
+@property LCLineChartData *selectedData;
+@property NSUInteger selectedIdx;
+
 @end
 
 
@@ -105,6 +108,8 @@
 
     self.drawsDataPoints = YES;
     self.drawsDataLines  = YES;
+    
+    self.selectedIdx = INT_MAX;
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
@@ -173,6 +178,8 @@
         }
         self.legendView.titles = titles;
         self.legendView.colors = colors;
+        self.selectedData = nil;
+        self.selectedIdx = INT_MAX;
 
         _data = data;
 
@@ -334,6 +341,7 @@
     CGFloat availableWidth = self.bounds.size.width - 2 * PADDING - self.yAxisLabelsWidth;
     CGFloat availableHeight = self.bounds.size.height - 2 * PADDING - X_AXIS_SPACE;
 
+    LCLineChartDataItem *closest = nil;
     LCLineChartData *closestData = nil;
     NSUInteger closestIdx = INT_MAX;
     double minDist = DBL_MAX;
@@ -354,6 +362,7 @@
             if(dist < minDist || (dist == minDist && distY < minDistY)) {
                 minDist = dist;
                 minDistY = distY;
+                closest = datItem;
                 closestData = data;
                 closestIdx = i;
                 closestPos = CGPointMake(xStart + xVal - 3, yStart + yVal - 7);
@@ -361,10 +370,12 @@
         }
     }
     
-    if(closestIdx == INT_MAX)
+    if(closest == nil || (closestData == self.selectedData && closestIdx == self.selectedIdx))
         return;
     
-    LCLineChartDataItem *closest = closestData.getData(closestIdx);
+    self.selectedData = closestData;
+    self.selectedIdx = closestIdx;
+    
     self.infoView.infoLabel.text = closest.dataLabel;
     self.infoView.tapPoint = closestPos;
     [self.infoView sizeToFit];
@@ -403,6 +414,8 @@
 - (void)hideIndicator {
     if(self.deselectedItemCallback)
         self.deselectedItemCallback();
+    
+    self.selectedData = nil;
     
     [UIView animateWithDuration:0.1 animations:^{
         self.infoView.alpha = 0.0;

--- a/ios-linechart/LCLineChartView.m
+++ b/ios-linechart/LCLineChartView.m
@@ -396,7 +396,7 @@
     }];
     
     if(self.selectedItemCallback != nil) {
-        self.deselectedItemCallback(closestData, closestIdx, closestPos);
+        self.selectedItemCallback(closestData, closestIdx, closestPos);
     }
 }
 

--- a/ios-linechart/LCLineChartView.m
+++ b/ios-linechart/LCLineChartView.m
@@ -308,12 +308,15 @@
                 [data.color setFill];
                 CGContextFillEllipseInRect(c, CGRectMake(xVal - 4, yVal - 4, 8, 8));
                 {
-                    CGFloat h,s,b,a;
+                    CGFloat brightness;
+                    CGFloat r,g,b,a;
                     if(CGColorGetNumberOfComponents([data.color CGColor]) < 3)
-                        [data.color getWhite:&b alpha:&a];
-                    else
-                        [data.color getHue:&h saturation:&s brightness:&b alpha:&a];
-                    if(b <= 0.5)
+                        [data.color getWhite:&brightness alpha:&a];
+                    else {
+                        [data.color getRed:&r green:&g blue:&b alpha:&a];
+                        brightness = 0.299 * r + 0.587 * g + 0.114 * b; // RGB ~> Luma conversion
+                    }
+                    if(brightness <= 0.68) // basically arbitrary, but works well for test cases
                         [[UIColor whiteColor] setFill];
                     else
                         [[UIColor blackColor] setFill];


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
